### PR TITLE
Fix blurred overlay for client pages

### DIFF
--- a/src/modules/client/ClientAppointments.tsx
+++ b/src/modules/client/ClientAppointments.tsx
@@ -10,14 +10,14 @@ export function ClientAppointments() {
 
   return (
     <div
-      className="min-h-screen bg-cover bg-center"
+      className="relative min-h-screen bg-cover bg-center"
       style={{
         backgroundImage:
           "url('https://images.pexels.com/photos/1813272/pexels-photo-1813272.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=2')",
       }}
     >
-      <div className="min-h-screen bg-black/50 backdrop-blur text-white">
-        <div className="p-6 space-y-6 max-w-5xl mx-auto">
+      <div className="absolute inset-0 bg-black/50 backdrop-blur-md" />
+      <div className="relative p-6 space-y-6 max-w-5xl mx-auto text-white">
           <h1 className="text-2xl font-bold">Meus Agendamentos</h1>
           <div className="overflow-x-auto">
             <table className="min-w-full text-sm">

--- a/src/modules/client/ClientDashboard.tsx
+++ b/src/modules/client/ClientDashboard.tsx
@@ -41,8 +41,9 @@ export const ClientDashboard: FC = () => {
   ];
 
   return (
-    <div className="min-h-screen bg-cover bg-center bg-[url('https://images.pexels.com/photos/1813272/pexels-photo-1813272.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=2')">      
-      <div className="min-h-screen bg-black/50 backdrop-blur-md text-white px-6 lg:px-12 flex flex-col gap-6 max-w-5xl mx-auto">
+    <div className="relative min-h-screen bg-cover bg-center bg-[url('https://images.pexels.com/photos/1813272/pexels-photo-1813272.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=2')">
+      <div className="absolute inset-0 bg-black/50 backdrop-blur-md" />
+      <div className="relative min-h-screen text-white px-6 lg:px-12 flex flex-col gap-6 max-w-5xl mx-auto">
         {/* Welcome Section */}
         <section className="bg-gray-800 rounded-xl shadow-lg border border-amber-500 p-6">
           <h1 className="text-2xl font-bold mb-2">Bem-vindo, {user?.name || 'Cliente'}!</h1>

--- a/src/modules/client/ClientHistoryPage.tsx
+++ b/src/modules/client/ClientHistoryPage.tsx
@@ -10,8 +10,9 @@ export function ClientHistoryPage() {
   const client = state.clients.find(c => c.fullName === user?.name);
 
   return (
-    <div className="min-h-screen bg-cover bg-center" style={{ backgroundImage: "url('https://images.pexels.com/photos/1813272/pexels-photo-1813272.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=2')" }}>
-      <div className="min-h-screen bg-black/50 backdrop-blur text-white p-6 space-y-6">
+    <div className="relative min-h-screen bg-cover bg-center" style={{ backgroundImage: "url('https://images.pexels.com/photos/1813272/pexels-photo-1813272.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=2')" }}>
+      <div className="absolute inset-0 bg-black/50 backdrop-blur-md" />
+      <div className="relative min-h-screen text-white p-6 space-y-6">
       <h1 className="text-2xl font-bold mb-4">Histórico de Serviços</h1>
       {client && client.serviceHistory.length > 0 ? (
         <div className="space-y-4">

--- a/src/modules/client/ClientProfilePage.tsx
+++ b/src/modules/client/ClientProfilePage.tsx
@@ -52,13 +52,14 @@ export function ClientProfilePage() {
 
   return (
     <div
-      className="min-h-screen bg-cover bg-center"
+      className="relative min-h-screen bg-cover bg-center"
       style={{
         backgroundImage:
           "url('https://images.pexels.com/photos/1813272/pexels-photo-1813272.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=2')",
       }}
     >
-      <div className="min-h-screen bg-black/50 backdrop-blur text-white">
+      <div className="absolute inset-0 bg-black/50 backdrop-blur-md" />
+      <div className="relative min-h-screen text-white">
         <div className="p-6 space-y-6 max-w-3xl mx-auto">
           <h1 className="text-2xl font-bold mb-4">Meu Perfil</h1>
         <div className="space-y-4">


### PR DESCRIPTION
## Summary
- overlay on client dashboard and profile/history/appointments pages now covers the full screen
- keep barbershop photo as the background under the blur

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685f075c87388325a08bc8a35edff593